### PR TITLE
Enable x264 support on heroku-16.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,9 @@ COPY Gemfile Gemfile
 COPY Gemfile.lock Gemfile.lock
 RUN ["bundle"]
 
+# Install libs for gif to mp4 conversion - also must be install on dyno, eg via Aptfile
+RUN apt-get update && apt-get install -y x264 libx264-148 libx264-dev
+
 ENV FFMPEG_DIR="${BUILD_DIR}/.ffmpeg"
 VOLUME ["${FFMPEG_DIR}.build"]
 

--- a/rakelib/ffmpeg.rake
+++ b/rakelib/ffmpeg.rake
@@ -27,7 +27,8 @@ module FFmpeg
     configure = File.absolute_path t.prerequisites.first
     prefix = File.absolute_path PREFIX
     Dir.chdir File.dirname t.name do
-      sh configure, "--prefix=#{prefix}", "--enable-nonfree", "--enable-gnutls", "--enable-libmp3lame"
+      # Enable libx264 (and gpl) for gif to mp4 conversion compatible with chrome, ff, ie.
+      sh configure, "--prefix=#{prefix}", "--enable-nonfree", "--enable-gnutls", "--enable-libmp3lame", "--enable-gpl", "--enable-libx264"
     end
   end
 


### PR DESCRIPTION
x264 support is required for converting gifs to mp4s compatible with
chrome, firefox, and IE. Requires following libs installed at compile time (on docker image)
and run time (on dyno) as well as the flag passed to the compilation
command:

* x264
* libx264-148
* libx264-dev